### PR TITLE
Add ShowIntrosOnMovies, ShowIntrosOnEpisodes flags

### DIFF
--- a/Jellyfin.Plugin.Intros/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Intros/Configuration/PluginConfiguration.cs
@@ -15,6 +15,10 @@ namespace Jellyfin.Plugin.Intros.Configuration
 
         public bool Random { get; set; } = false;
 
+        public bool ShowIntrosOnMovies { get; set; } = true;
+
+        public bool ShowIntrosOnEpisodes { get; set; } = false;
+
         // used internally to track the current intro
         public Guid Id { get; set; }
     }

--- a/Jellyfin.Plugin.Intros/Configuration/config.html
+++ b/Jellyfin.Plugin.Intros/Configuration/config.html
@@ -135,6 +135,18 @@
                             <span>Randomize Intro</span>
                         </label>
                     </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label for="showIntrosOnMovies" class="emby-checkbox-label">    
+                            <input id="showIntrosOnMovies" type="checkbox" is="emby-checkbox" />
+                            <span>Show Intros on Movies</span>
+                        </label>
+                    </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label for="showIntrosOnEpisodes" class="emby-checkbox-label">    
+                            <input id="showIntrosOnEpisodes" type="checkbox" is="emby-checkbox" />
+                            <span>Show Intros on Episodes</span>
+                        </label>
+                    </div>
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block emby-button">
                             <span>Save</span>
@@ -156,6 +168,8 @@
                     document.querySelector('#intro').value = config.Intro;
                     document.querySelector('#resolution').value = config.Resolution;
                     document.querySelector('#random').checked = config.Random;
+                    document.querySelector('#showIntrosOnMovies').checked = config.ShowIntrosOnMovies;
+                    document.querySelector('#showIntrosOnEpisodes').checked = config.ShowIntrosOnEpisodes;
 
                     if (config.Local) {
                         document.querySelector('#vimeo').disabled = true;
@@ -207,6 +221,8 @@
                     config.Intro = document.querySelector('#intro').value;
                     config.Resolution = document.querySelector('#resolution').value;
                     config.Random = document.querySelector('#random').checked;
+                    config.ShowIntrosOnMovies = document.querySelector("#showIntrosOnMovies").checked;
+                    config.ShowIntrosOnEpisodes = document.querySelector("#showIntrosOnEpisodes").checked;
 
                     ApiClient.updatePluginConfiguration(plugin.guid, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin.Plugin.Intros/IntroProvider.cs
+++ b/Jellyfin.Plugin.Intros/IntroProvider.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Data.Entities;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 
 namespace Jellyfin.Plugin.Intros
@@ -13,8 +15,14 @@ namespace Jellyfin.Plugin.Intros
 
         public Task<IEnumerable<IntroInfo>> GetIntros(BaseItem item, User user)
         {
-            var introManager = new IntroManager();
-            return Task.FromResult(introManager.Get());
+            var showIntrosOnMovies = Plugin.Instance.Configuration.ShowIntrosOnMovies;
+            var showIntrosOnEpisodes = Plugin.Instance.Configuration.ShowIntrosOnEpisodes;
+
+            return Task.FromResult(item switch {
+                Movie when showIntrosOnMovies is false => Enumerable.Empty<IntroInfo>(),
+                Episode when showIntrosOnEpisodes is false => Enumerable.Empty<IntroInfo>(),
+                _ => new IntroManager().Get()
+            });
         }
 
         public IEnumerable<string> GetAllIntroFiles()


### PR DESCRIPTION
This PR will add two checkboxes to the settings page that allow turning on or off showing intros for movies or episodes independently.

I've chosen the defaults to match what was requested in #54 (i.e. Movies on, Episodes off).